### PR TITLE
Add trace_start!() macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,3 +204,13 @@ macro_rules! try_rethrow {
         }
     })
 }
+
+#[macro_export]
+macro_rules! trace_start {
+    ($err:expr) => {
+        ::std::result::Result::Err($crate::Trace::new(
+            ::std::convert::From::from($err),
+            ::std::boxed::Box::new($crate::backtrace::SourceBacktrace::new(line!(), file!()))
+        ))
+    }
+}


### PR DESCRIPTION
It is like `try_throw!()` except without the `return`.  I found it useful for instance in the context of iterator producing `Result<>`s where you still want to wrap the return value in `Some()`.